### PR TITLE
Fix OSX Problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required (VERSION 3.1)
 
+IF(APPLE)
+    SET(CMAKE_C_COMPILER clang)
+    SET(CMAKE_CXX_COMPILER clang++)
+ENDIF()
+
 project (AIC19-Client-Cpp
     LANGUAGES CXX)
 


### PR DESCRIPTION
Suggest add this line to CMake to force use of `clang` in`osx`.
related #10 
